### PR TITLE
Fix: Uncommented joint_pos_cmd lines in effort_controller_base

### DIFF
--- a/effort_controller_base/src/effort_controller_base.cpp
+++ b/effort_controller_base/src/effort_controller_base.cpp
@@ -420,11 +420,11 @@ void EffortControllerBase::writeJointEffortCmds() {
       }
     }
   }
-  // if (m_command_current_configuration_ == true) {
-  //   for (size_t i = 0; i < m_joint_number; ++i) {
-  //     m_joint_cmd_pos_handles[i].get().set_value(m_joint_positions(i));
-  //   }
-  // }
+  if (m_command_current_configuration_ == true) {
+    for (size_t i = 0; i < m_joint_number; ++i) {
+      m_joint_cmd_pos_handles[i].get().set_value(m_joint_positions(i));
+    }
+  }
 }
 
 void EffortControllerBase::computeJointEffortCmds(const ctrl::VectorND &tau) {


### PR DESCRIPTION
**Bug:**  Joint Position are currently not updated by the effort_controller which can lead exceptions on the Kuka robot due to drifting from it's commanded (initial) position.
Some lines were commented out in the [effort_controller_base.cpp](effort_controller_base/src/effort_controller_base.cpp) probably due to testing.

**Fix:** Uncomment ll. 423-427 in [effort_controller_base.cpp](effort_controller_base/src/effort_controller_base.cpp)

For more information see this [issue](https://github.com/idra-lab/kuka_lbr_control/issues/6)